### PR TITLE
Replace example repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ prebuild-stats author/package [options]
 
 Example
 ```
-prebuild-stats Level/leveldown
+prebuild-stats lovell/sharp
 ```
 
 ## License


### PR DESCRIPTION
- The example `Level/leveldown` no longer depends on `prebuild-install`.
- A popular dependent is `lovell/sharp`, with 35k+ downloads for release `v0.25.2`.

See

- https://www.npmjs.com/package/prebuild-install?activeTab=dependents
- https://github.com/lovell/sharp/releases/tag/v0.25.2
- https://github.com/prebuild/prebuild-stats/issues/1

Fixes #1.